### PR TITLE
Use knife supermarket instead of knife cookbook site

### DIFF
--- a/tasks/publish_supermarket/publish_supermarket.ts
+++ b/tasks/publish_supermarket/publish_supermarket.ts
@@ -47,7 +47,7 @@ async function run() {
     }
 
     // set the command and the arguments that are to be run
-    let command_args = sprintf("cookbook site share %s -o %s -m %s -u %s -k %s", params["chefCookbookName"], params["chefCookbookPath"], params["chefServiceUrl"], params["chefUsername"], key_filename);
+    let command_args = sprintf("supermarket share %s -o %s -m %s -u %s -k %s", params["chefCookbookName"], params["chefCookbookPath"], params["chefServiceUrl"], params["chefUsername"], key_filename);
 
     // publish the named cookbook to the supermaket
     try {


### PR DESCRIPTION
Several years ago we started the process of replacing knife cookbook
site with knife supermarket. In Chef 15 we introduce a deprecation
warning when knife cookbook site is used and in Chef 16 we will remove
the knife cookbook site command entirely. This avoids the deprecation
warning by using the correct command.

Signed-off-by: Tim Smith <tsmith@chef.io>